### PR TITLE
Added isGovernmentRepo field to the relatedCode object

### DIFF
--- a/schemas/schema-2.0.0.json
+++ b/schemas/schema-2.0.0.json
@@ -198,6 +198,10 @@
                   "type": "string",
                   "format": "uri",
                   "description": "The URL where the code repository, project, library or release can be found."
+                },
+                "isGovernmentRepo": {
+                  "type": "boolean",
+                  "description": "True or False. Is the code repository owned or managed by a federal agency?"
                 }
               },
               "additionalProperties": false


### PR DESCRIPTION
Added isGovernmentRepo field to the __relatedCode__ object. This field should have always been a part of the schema.