### PR TITLE
Updating SBA and DOT compliance update Feb IDC followup.

### DIFF
--- a/agency_metadata.json
+++ b/agency_metadata.json
@@ -197,9 +197,9 @@
     "codeUrl": "https://www.transportation.gov/code.json",
     "fallback_file": "DOT.json",
     "requirements": {
-      "agencyWidePolicy": 1.0,
-      "openSourceRequirement": 0.5,
-      "inventoryRequirement": 0,
+      "agencyWidePolicy": 1,
+      "openSourceRequirement": 1,
+      "inventoryRequirement": 1,
       "schemaFormat": 0.5,
       "overallCompliance": 0
     },
@@ -349,7 +349,7 @@
     "fallback_file": "SBA.json",
     "requirements": {
       "agencyWidePolicy": 1,
-      "openSourceRequirement": 0,
+      "openSourceRequirement": 1,
       "inventoryRequirement": 0,
       "schemaFormat": 0.5,
       "overallCompliance": 0


### PR DESCRIPTION
SBA and DOT have made progressed based on the IDC report and would like to be credited for their work. 

DOT has open source 42% of their inventory, and completed a comprehensive inventory.

SBA has open source 100% of the repos that have been inventoried. Inventory is not complete.