### PR TITLE
Treasure & NSF compliance update

### DIFF
--- a/agency_metadata.json
+++ b/agency_metadata.json
@@ -213,7 +213,7 @@
     "codeUrl": "https://www.treasury.gov/code.json",
     "fallback_file": "TREASURY.json",
     "requirements": {
-      "agencyWidePolicy": 0.75,
+      "agencyWidePolicy": 1.0,
       "openSourceRequirement": 0,
       "inventoryRequirement": 0,
       "schemaFormat": 0.5,
@@ -305,7 +305,7 @@
     "requirements": {
       "agencyWidePolicy": 1,
       "openSourceRequirement": 1,
-      "inventoryRequirement": 1,
+      "inventoryRequirement": 0.5,
       "schemaFormat": 0.5,
       "overallCompliance": 0
     },


### PR DESCRIPTION
 @jcastle Received and approved Treasury's Open Source Policy. Tony @ Treasury would like to be credited on the compliance dashboard. 

Also, NSF has not completed their Software Inventory across all departments, moving it to yellow. 